### PR TITLE
Init the synthies fourier sage project

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "Sage/StudentProjects/the-synthies"]
+	path = Sage/StudentProjects/the-synthies
+	url = https://github.com/Splines/fourier-sage-playground.git
+	branch = main


### PR DESCRIPTION
We leverage GitHub submodules to point to our [own repo](https://github.com/Splines/fourier-sage-playground) for the Fourier project (currently under construction). This is just to be more flexible and not limited to changes within one PR. The folder will appear as "the-synthies" as can be seen [here](https://github.com/Splines/CompAssistedMath2024/tree/team/init-the-synthies-fourier-sage-project/Sage/StudentProjects).

## Update commit later on
Note that despite specifying a _branch_ instead of a specific _commit_ inside the `.gitmodules` file, the submodule will still only reference to a specific commit. This is described [here](https://stackoverflow.com/a/18797720/9655481) in more detail at the end.

Therefore, you as project owners of the `CompAssistedMath2024` repo are in full control over this new folder and where it points to. If you want to update its contents later on to point to a newer commit on the submodule's `main` branch, do the following (I will file in another PR to do exactly that before the deadline next week):

```bash
git submodule update --remote
git add .
```
